### PR TITLE
Updating paragraph id / text constants to match the fields the others…

### DIFF
--- a/src/main/kotlin/edu/unh/cs980/KotlinUtils.kt
+++ b/src/main/kotlin/edu/unh/cs980/KotlinUtils.kt
@@ -61,5 +61,5 @@ fun getIndexSearcher(indexLocation: String): IndexSearcher {
 }
 
 // Constants referring to Lucene fields
-const val PID: String = "paragraphid"
-const val CONTENT = "text"
+const val PID: String = "paraid"
+const val CONTENT = "content"


### PR DESCRIPTION
Since the group members are using different field names, updating my constants to reflect their versions of field names.